### PR TITLE
Break out merge into a separate dag and fix the start date

### DIFF
--- a/airflow/post_install.sh
+++ b/airflow/post_install.sh
@@ -12,7 +12,7 @@ python $AIRFLOW_HOME/utils/set_default_variables.py \
     source_dataset="{{ var.value.PIPELINE_DATASET }}" \
     source_table="position_messages_" \
     raw_table="raw_encounters_" \
-    encounters_table="encounters_" \
+    encounters_table="encounters" \
 
 echo "Installation Complete"
 


### PR DESCRIPTION
Closes #12 

- Separate the Merge operation into a separate dag and only run it daily.   The idea is that you leave it turned off when running the monthly tasks for backfill and then turn it on once everything is up to date

- Fix the start date to be the pipeline startdate

