### PR TITLE
Output neighbors table from raw_encounters

### DIFF
--- a/airflow/encounters_dag.py
+++ b/airflow/encounters_dag.py
@@ -97,6 +97,7 @@ def build_dag(dag_id, schedule_interval):
                 end_date=end_date,
                 source_table='{project_id}:{source_dataset}.{source_table}'.format(**config),
                 raw_table='{project_id}:{pipeline_dataset}.{raw_table}'.format(**config),
+                neighbor_table='{project_id}:{pipeline_dataset}.{neighbor_table}'.format(**config),
                 temp_location='gs://{temp_bucket}/dataflow_temp'.format(**config),
                 staging_location='gs://{temp_bucket}/dataflow_staging'.format(**config),
                 max_num_workers="100",

--- a/airflow/post_install.sh
+++ b/airflow/post_install.sh
@@ -13,6 +13,7 @@ python $AIRFLOW_HOME/utils/set_default_variables.py \
     source_table="position_messages_" \
     raw_table="raw_encounters_" \
     encounters_table="encounters" \
+    neighbor_table="raw_encounters_neighbors_"
 
 echo "Installation Complete"
 


### PR DESCRIPTION
Close #16

add `--neighbor_table parameter` in the airflow configuration so that raw_encounters writes out neighbors to a separate table for use in the features pipeline