### PR TITLE
Backfill flag

### DIFF
--- a/airflow/encounters_dag.py
+++ b/airflow/encounters_dag.py
@@ -109,7 +109,7 @@ def build_dag(dag_id, schedule_interval):
 
         dag >> source_exists >> create_raw_encounters
 
-        if schedule_interval == '@daily':
+        if not config.get('backfill', False):
             merge_encounters = DataFlowPythonOperator(
                 task_id='merge-encounters',
                 pool='dataflow',

--- a/airflow/post_install.sh
+++ b/airflow/post_install.sh
@@ -13,7 +13,8 @@ python $AIRFLOW_HOME/utils/set_default_variables.py \
     source_table="position_messages_" \
     raw_table="raw_encounters_" \
     encounters_table="encounters" \
-    neighbor_table="raw_encounters_neighbors_"
+    neighbor_table="raw_encounters_neighbors_" \
+    backfill=""
 
 echo "Installation Complete"
 


### PR DESCRIPTION
Closes #24 

Add an airflow variable `backfill` that when set, skips the merge_encounters task.   This way you can run the monthly or daily tasks to create raw encounters, then turn off backfill so that merge runs only after all the days/months are generated