### PR TITLE
Adds testing function that includes tolerance in floating point comparation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,23 @@ language: python
 
 sudo: required
 
-services: docker
+services:
+  - docker
 
 cache:
   directories:
   - ~/.cache/pip
 
 python:
-- 2.7
+- 3.7
 
 install:
-  - docker volume create --name=gcp
   - docker-compose build
 
 script:
-  - docker-compose --version
   - docker-compose run test
+
+notifications:
+  slack:
+    rooms:
+      secure: DnyIVNrhSXyHl8Jtrvp74uSyzJnc/YWy+XE3L3sKbGeKj+4FyOYlIzUZq/AzZQ2J+UTy68C/HnWovMX421bRaKIvfcHH6nSvP4mEMig75f6CPKAQ/NvToT/9V/nMWEc9WoPFzjRvT+b3Wzt0c3YtsIPs86ASSN/3J27bhnOnzFPeOAEAOyFNx1E0lzVfnk6ranKCvmZGVaFRNRRbj/bFRkpjPepLfor9AK/vjIquGEuhTNezZSD1YonxHh45qvZ5B6/1+BJ/IUWGmY9/AX2FWdn6+JSH/EPGRaXnAWDwoaja6msJ+JsgjHUIcXA5Kxb93rXvRrTIcFeV7pnnE/RIFH76JM13k5YDT/YwCukIav4w4ORKiEJWiRN+nzqe4ya+DR3Fo/K70px8ZQdWGp6dja465NJ+Ji/Y1LfWOucyzX/zCeWeX2ak1bQZY9oGvjCU4Eaqd5sWKT40iakKKwK1b8dEHft5eMbTWdhIeye/0Mo5J1BI0gxR0SvHwScAoAyOGWdsBKL33yzWWso/UcoPGlP7SuslKvRNK5YpNy4HZMy4UQQJ0gMvaBPqlz+CVA5F3N/tdBI/Z5pdmbza8ZIxZvaJtZS7/8l0EVwG3YnD/5xWF/pJ3sYrL3/kKlts1N+DSkCOFoFFtZp8AsOVPqvSDVQo6Fbynp0HIpFs4WvpNPw=

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,14 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+## v3.0.6 - 2020-11-04
+
+### Changed
+
+* [Data Pipeline/PIPELINE-229](https://globalfishingwatch.atlassian.net/browse/PIPELINE-229): Changes
+  * Pin to `pipe-tools:v3.1.3` that has the compare function with floating tolerance `approx_equal_to`.
+  * Replace the use of `equal_to` of beam to `approx_equal_to` in computation tests.
+
 ## v3.0.5 - 2020-11-02
 
 ### Changed

--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -4,7 +4,7 @@ Apache Beam pipeline for computing vessel encounters.
 
 
 
-__version__ = '3.0.5'
+__version__ = '3.0.6'
 __author__ = 'Global Fishing Watch'
 __email__ = 'info@globalfishingwatch.org'
 __source__ = 'https://github.com/GlobalFishingWatch/anchorages_pipeline'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-https://codeload.github.com/GlobalFishingWatch/pipe-tools/tar.gz/v3.1.2#egg=pipe-tools
+https://codeload.github.com/GlobalFishingWatch/pipe-tools/tar.gz/v3.1.3#egg=pipe-tools

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ DEPENDENCIES = [
     "statistics",
     "more_itertools",
     "s2sphere",
-    "pipe-tools==3.1.2",
+    "pipe-tools==3.1.3",
     "jinja2-cli",
     "six>=1.13",
     "cython"

--- a/tests/test_compute_encounters.py
+++ b/tests/test_compute_encounters.py
@@ -1,29 +1,32 @@
-import pytest
-import unittest
-import logging
-from collections import namedtuple
-from collections import OrderedDict
-import datetime
-import pytz
-
-import apache_beam as beam
-from apache_beam import Map
-from apache_beam.testing.test_pipeline import TestPipeline as _TestPipeline
-from apache_beam.testing.util import assert_that
-from apache_beam.testing.util import equal_to
+from .series_data import real_series_data
+from .series_data import simple_series_data, dateline_series_data
 
 from .test_resample import Record
 from .test_resample import ResampledRecord
-from .series_data import simple_series_data, dateline_series_data
-from .series_data import real_series_data
+
+from apache_beam import Map
+from apache_beam.testing.test_pipeline import TestPipeline as _TestPipeline
+from apache_beam.testing.util import assert_that
+
+from collections import OrderedDict
+from collections import namedtuple
+
+from pipe_tools.utils import approx_equal_to as equal_to
 
 from pipeline.create_raw_pipeline import ensure_bytes_id
-from pipeline.transforms.resample import Resample
+from pipeline.objects import encounter
 from pipeline.transforms.compute_adjacency import ComputeAdjacency
 from pipeline.transforms.compute_encounters import ComputeEncounters
-from pipeline.objects import encounter
 from pipeline.transforms.merge_encounters import MergeEncounters
+from pipeline.transforms.resample import Resample
+
+import apache_beam as beam
+import datetime
+import logging
+import pytest
 import pytz
+import pytz
+import unittest
 
 
 logger = logging.getLogger()


### PR DESCRIPTION
* Uses the `approx_equal_to` that Tim did in `pipe-tools:v3.1.3` that fixes the tests.
(Uses `from pipe_tools.utils import approx_equal_to as equal_to` instead of `from apache_beam.testing.util import equal_to` and sort the imports.)
* Increments versions, `pipe-tools:v3.1.3` that has the change of Tim and the encounters_pipeline.
* Updates `.travis.yaml` (**NOTE** to enable travis as a project we need to change the visibility from `private` to `public`)

Test run ok: **10 passed, 3 warnings in 6.66s**

Related with> https://globalfishingwatch.atlassian.net/browse/PIPELINE-229