### PR TITLE
Adds support for Apache Beam 2.28.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,74 +8,82 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+## v3.1.0 - 2021-04-29
+
+### Added
+
+* [Data Pipeline/PIPELINE-84](https://globalfishingwatch.atlassian.net/browse/PIPELINE-84): Adds
+  support of Apache Beam `2.28.0`.
+  Increments Google SDK version to `338.0.0`.
+
 ## v3.0.7 - 2020-11-06
 
 ### Changed
 
 * [Data Pipeline/PIPELINE-231](https://globalfishingwatch.atlassian.net/browse/PIPELINE-231): Changes
-  * Updates the `dist_to_port_10km.pickle` with the new raster `distance_to_port_0p01_v20201104.tiff`.
+  Updates the `dist_to_port_10km.pickle` with the new raster `distance_to_port_0p01_v20201104.tiff`.
 
 ## v3.0.6 - 2020-11-04
 
 ### Changed
 
 * [Data Pipeline/PIPELINE-229](https://globalfishingwatch.atlassian.net/browse/PIPELINE-229): Changes
-  * Pin to `pipe-tools:v3.1.3` that has the compare function with floating tolerance `approx_equal_to`.
-  * Replace the use of `equal_to` of beam to `approx_equal_to` in computation tests.
+  Pin to `pipe-tools:v3.1.3` that has the compare function with floating tolerance `approx_equal_to`.
+  Replace the use of `equal_to` of beam to `approx_equal_to` in computation tests.
 
 ## v3.0.5 - 2020-11-02
 
 ### Changed
 
 * [Data Pipeline/PIPELINE-142](https://globalfishingwatch.atlassian.net/browse/PIPELINE-142): Changes
-  * Fix lon averaging across dateline for encounter creation.
-  * Fix lon averaging for merging.
-  * Fix existing tests and add new tests for creation and merging near dateline.
+  Fix lon averaging across dateline for encounter creation.
+  Fix lon averaging for merging.
+  Fix existing tests and add new tests for creation and merging near dateline.
 
 ## v3.0.4 - 2020-09-18
 
 ### Changed
 
 * [Data Pipeline/PIPELINE-106](https://globalfishingwatch.atlassian.net/browse/PIPELINE-106): Changes
-  * Successive runs of merge_encounters on the same data can give slightly
-  * different result.  The culprit turned out to be that sorting the incoming
-  * raw_encounters by start_time alone was not completely stable since there
-  * could by ties in start time. The solution was to stabilize the search by
-  * including the end time and vessel_ids as secondary keys.
+  Successive runs of merge_encounters on the same data can give slightly
+  different result.  The culprit turned out to be that sorting the incoming
+  raw_encounters by start_time alone was not completely stable since there
+  could by ties in start time. The solution was to stabilize the search by
+  including the end time and vessel_ids as secondary keys.
 
 ## v3.0.3 - 2020-06-11
 
 ### Added
 
 * [GlobalFishingWatch/gfw-eng-tasks#111](https://github.com/GlobalFishingWatch/gfw-eng-tasks/issues/111): Adds
-  * Pin to `pipe-tools:v3.1.2`.
+  Pin to `pipe-tools:v3.1.2`.
 
 ## v3.0.2 - 2020-03-18
 
 ### Added
 
 * [GlobalFishingWatch/gfw-eng-tasks#37](https://github.com/GlobalFishingWatch/gfw-eng-tasks/issues/37): Adds
-   required position_messages and segments table passed as requiered in create_raw_encounters.
+  required position_messages and segments table passed as requiered in create_raw_encounters.
 
 ## v3.0.1 - 2020-03-13
 
 ### Changed
 
 * [GlobalFishingWatch/gfw-eng-tasks#32](https://github.com/GlobalFishingWatch/gfw-eng-tasks/issues/32): Changes
-   hardcoded `segment` to `legacy_segment_v1_` table.
+  hardcoded `segment` to `legacy_segment_v1_` table.
 
 ## v3.0.0 - 2020-03-12
 
 ### Changed
 
 * [GlobalFishingWatch/gfw-eng-tasks#31](https://github.com/GlobalFishingWatch/gfw-eng-tasks/issues/31): Changes
-   pin `ujson` lib to `1.35` and `pipe-tools:v3.1.1`.
-   Dockerfile update just needed lines.
+  pin `ujson` lib to `1.35` and `pipe-tools:v3.1.1`.
+  Dockerfile update just needed lines.
 
 ### Added
 
 * [GlobalFishingWatch/gfw-eng-tasks#29](https://github.com/GlobalFishingWatch/gfw-eng-tasks/issues/29): Adds
-    `dist_to_port_10km.pickle` file having the new raster.
+  `dist_to_port_10km.pickle` file having the new raster.
 
 
 ## v2.0.0 - 2020-01-29
@@ -83,30 +91,30 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 ### Changed
 
 * [GlobalFishingWatch/GFW-Tasks#1166](https://github.com/GlobalFishingWatch/GFW-Tasks/issues/1166): Changes
-   * supports [pipe-tools:v3.1.0](https://github.com/GlobalFishingWatch/pipe-tools/releases/tag/v3.1.0)
-   * Migrates `Apache Beam` from version 2.1.0 to [2.16.0](https://github.com/apache/beam/tree/v2.16.0)
-   * Migrates from pytohn 2 to 3.
+  supports [pipe-tools:v3.1.0](https://github.com/GlobalFishingWatch/pipe-tools/releases/tag/v3.1.0)
+  Migrates `Apache Beam` from version 2.1.0 to [2.16.0](https://github.com/apache/beam/tree/v2.16.0)
+  Migrates from pytohn 2 to 3.
 
 ## v1.0.0 - 2019-03-27
 
 ### Added
 
 * [GlobalFishingWatch/GFW-Tasks#991](https://github.com/GlobalFishingWatch/GFW-Tasks/issues/991)
-   * Migrates to use the new [airflow-gfw](https://github.com/GlobalFishingWatch/airflow-gfw) library and use the pipe-tools [v2.0.0](https://github.com/GlobalFishingWatch/pipe-tools/releases/tag/v2.0.0)
+  Migrates to use the new [airflow-gfw](https://github.com/GlobalFishingWatch/airflow-gfw) library and use the pipe-tools [v2.0.0](https://github.com/GlobalFishingWatch/pipe-tools/releases/tag/v2.0.0)
 
 ## 0.3.3
 
 * [GlobalFishingWatch/GFW-Tasks#990](https://github.com/GlobalFishingWatch/GFW-Tasks/issues/990)
-  * Support the Yearly mode
-* Remove noise segments using the segment table noise flag.
+  Support the Yearly mode
+  Remove noise segments using the segment table noise flag.
 
 ## 0.3.2
 
 * [GlobalFishingWatch/GFW-Tasks#957](https://github.com/GlobalFishingWatch/GFW-Tasks/issues/957)
-  * Increments version of pipe_tools to 0.2.5.
-  * Ensures the creation of raw_encounters table before merge_encounters pipeline starts.
+  Increments version of pipe_tools to 0.2.5.
+  Ensures the creation of raw_encounters table before merge_encounters pipeline starts.
 
-## 0.3.1 2018-10-19
+## 0.3.1 - 2018-10-19
 
 * [#36](https://github.com/GlobalFishingWatch/encounters_pipeline/pull/36)
   Update the Distance to Port Mask
@@ -114,52 +122,52 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 ## 0.3.0 - 2018-09-07
 
 * [#38](https://github.com/GlobalFishingWatch/encounters_pipeline/pull/38)
-  * Removes the publication of events from this pipeline, which will be handled on [pipe-events](https://github.com/globalfishingwatch/pipe-events). See [pipe-events#7](https://github.com/GlobalFishingWatch/pipe-events/pull/7).
+  Removes the publication of events from this pipeline, which will be handled on [pipe-events](https://github.com/globalfishingwatch/pipe-events). See [pipe-events#7](https://github.com/GlobalFishingWatch/pipe-events/pull/7).
 
 
-## 0.2.1 2018-09-03
+## 0.2.1 - 2018-09-03
 
 * [#37](https://github.com/GlobalFishingWatch/encounters_pipeline/pull/37)
-  * Bump version of pipe-tools to 0.1.7
+  Bump version of pipe-tools to `0.1.7`
 
-## 0.2.0 2018-05-14
+## 0.2.0 - 2018-05-14
 
 * [#32](https://github.com/GlobalFishingWatch/encounters_pipeline/pull/32)
-  * Publish standardized encounter events
+  Publish standardized encounter events
 
 
-## 0.1.19 2018-03-12
+## 0.1.19 - 2018-03-12
 
 * [#28](https://github.com/GlobalFishingWatch/encounters_pipeline/pull/28)
-  * Refactor airflow
+  Refactor airflow
 
 
-## 0.1.18 2018-02-08
+## 0.1.18 - 2018-02-08
 
 * [#23](https://github.com/GlobalFishingWatch/encounters_pipeline/pull/23)
-  * Filter encounters output to the specified date range
+  Filter encounters output to the specified date range
 * [#25](https://github.com/GlobalFishingWatch/encounters_pipeline/pull/25)
-  * Added a backfill flag to disable running the encounters_merge dag task when backfilling
+  Added a backfill flag to disable running the encounters_merge dag task when backfilling
 
 
 ## 0.1.17 2018-02-05
 
 * [#11](https://github.com/GlobalFishingWatch/encounters_pipeline/pull/11)
-  * Filter out inland encounters
+  Filter out inland encounters
 * [#21](https://github.com/GlobalFishingWatch/encounters_pipeline/pull/21)
-  * Combine airflow create_raw_encounters with merge_encoutners for the daily run
+  Combine airflow create_raw_encounters with merge_encoutners for the daily run
 
 
 ## 0.1.16
 
 * [#13](https://github.com/GlobalFishingWatch/encounters_pipeline/pull/13)
-  * Break out merge into a separate dag and fix the start date
+  Break out merge into a separate dag and fix the start date
 * [#17](https://github.com/GlobalFishingWatch/encounters_pipeline/pull/17)
-  * add --neighbor_table parameter in the airflow configuration so that raw_encounters
-  * writes out neighbors to a separate table for use in the features pipeline
+  add --neighbor_table parameter in the airflow configuration so that raw_encounters
+  writes out neighbors to a separate table for use in the features pipeline
 
 
 ## 0.1.15
 
 * [#8](https://github.com/GlobalFishingWatch/encounters_pipeline/pull/8)
-  * Reorg and rename parameters to match the latest airflow mini-pipeline architecture
+  Reorg and rename parameters to match the latest airflow mini-pipeline architecture

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /opt/project
 
 # Download and install google cloud. See the dockerfile at
 # https://hub.docker.com/r/google/cloud-sdk/~/dockerfile/
-ENV CLOUD_SDK_VERSION 268.0.0
+ENV CLOUD_SDK_VERSION 338.0.0
 RUN  \
   export CLOUD_SDK_APT_DEPS="curl gcc python-dev python-setuptools apt-transport-https lsb-release openssh-client git" && \
   export CLOUD_SDK_PIP_DEPS="crcmod" && \

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,7 +22,7 @@ services:
       - ".:/opt/project"
       - "gcp:/root/.config/"
   test:
-    entrypoint: ["py.test",  "tests"]
+    entrypoint: "py.test"
     image: gfw/pipe-encounters
     build: .
     volumes:

--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -2,9 +2,7 @@
 Apache Beam pipeline for computing vessel encounters.
 """
 
-
-
-__version__ = '3.0.7'
+__version__ = '3.1.0'
 __author__ = 'Global Fishing Watch'
 __email__ = 'info@globalfishingwatch.org'
 __source__ = 'https://github.com/GlobalFishingWatch/anchorages_pipeline'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-https://codeload.github.com/GlobalFishingWatch/pipe-tools/tar.gz/v3.1.3#egg=pipe-tools
+https://codeload.github.com/GlobalFishingWatch/pipe-tools/tar.gz/v3.2.0#egg=pipe-tools

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ DEPENDENCIES = [
     "statistics",
     "more_itertools",
     "s2sphere",
-    "pipe-tools==3.1.3",
+    "pipe-tools==3.2.0",
     "jinja2-cli",
     "six>=1.13",
     "cython"

--- a/tests/test_compute_adjacency.py
+++ b/tests/test_compute_adjacency.py
@@ -15,6 +15,7 @@ from .test_resample import ResampledRecord
 from .series_data import simple_series_data
 from pipeline.transforms import compute_adjacency
 from pipeline.transforms import resample
+from pipeline.options.create_options import CreateOptions
 
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
@@ -39,7 +40,21 @@ class TestComputeAdjacency(unittest.TestCase):
 
     def test_with_resampling(self):
 
-        with _TestPipeline() as p:
+        args=[
+            f'--source_dataset={simple_series_data}',
+            '--position_messages_table=xxx',
+            '--segments_table=xxx',
+            '--raw_table=xxx',
+            '--start_date=2021-01-01',
+            '--end_date=2021-01-01',
+            '--max_encounter_dist_km=1.0',
+            '--min_encounter_time_minutes=120',
+            '--runner=DirectRunner'
+        ]
+        with _TestPipeline(options=CreateOptions(args)) as p:
+            print('==============SIMPLE DATA====================')
+            print(simple_series_data)
+            print('==============SIMPLE DATA====================')
             results = (
                 p
                 | beam.Create(simple_series_data)


### PR DESCRIPTION
Related with> https://globalfishingwatch.atlassian.net/browse/PIPELINE-84

Test are not working.
There is an error using the assert_that :
from apache_beam.testing.util import assert_that
I should need to continue working on the tests.
However the pipeline was tested versus pipe_production_v20201001 and results were placed in scratch_matias_ttl_60_days and there were some differences:
```
SELECT count(*) FROM `world-fishing-827.scratch_matias_ttl_60_days.20210502_encounters`
-- 1916
SELECT count(*) FROM `world-fishing-827.pipe_production_v20201001.encounters`
where DATE(end_time)= date('2021-05-01')
-- 1982

select count(*) from `scratch_matias_ttl_60_days.raw_encounters_20210501`
-- 186756
select count(*) from `pipe_production_v20201001.raw_encounters_20210501`
-- 186753
```
