### PR TITLE
Handle null course

### DIFF
--- a/pipeline/transforms/sort_by_time.py
+++ b/pipeline/transforms/sort_by_time.py
@@ -1,23 +1,24 @@
 from __future__ import division
-from collections import defaultdict
+
 import math
-from apache_beam import PTransform
-from apache_beam import Map
-from apache_beam import typehints
+from collections import defaultdict
+
+from apache_beam import Map, PTransform
 
 from ..objects.record import Record
 
 
 def median(iterable):
     seq = sorted(iterable)
+    if not seq:
+        return None
     quotient, remainder = divmod(len(seq), 2)
     if remainder:
         return seq[quotient]
-    return sum(seq[quotient - 1:quotient + 1]) / 2
+    return sum(seq[quotient - 1 : quotient + 1]) / 2
 
 
 class SortByTime(PTransform):
-
     def sort_and_uniquify_by_time(self, item):
         key, records = item
         time_map = defaultdict(list)
@@ -30,20 +31,30 @@ class SortByTime(PTransform):
             records_at_t = time_map[t]
             id_ = records_at_t[0].id
             assert [x.id == id_ for x in records_at_t]
-            sorted_records.append(Record(
-                id = id_,
-                timestamp = t,
-                lat = median(x.lat for x in records_at_t),
-                lon = median(x.lon for x in records_at_t),
-                speed = median(x.speed for x in records_at_t),
-                course = math.degrees(math.atan2(
-                                median(math.sin(math.radians(x.course)) for x in records_at_t),
-                                median(math.cos(math.radians(x.course)) for x in records_at_t)))
-                ))
+            sorted_records.append(
+                Record(
+                    id=id_,
+                    timestamp=t,
+                    lat=median(x.lat for x in records_at_t),
+                    lon=median(x.lon for x in records_at_t),
+                    speed=median(x.speed for x in records_at_t if x is not None),
+                    course=math.degrees(
+                        math.atan2(
+                            median(
+                                math.sin(math.radians(x.course))
+                                for x in records_at_t
+                                if x is not None
+                            ),
+                            median(
+                                math.cos(math.radians(x.course))
+                                for x in records_at_t
+                                if x is not None
+                            ),
+                        )
+                    ),
+                )
+            )
         return key, sorted_records
 
     def expand(self, xs):
-        return (
-            xs
-            | Map(self.sort_and_uniquify_by_time)
-        )
+        return xs | Map(self.sort_and_uniquify_by_time)


### PR DESCRIPTION
@bitsofbits fixes the issue where the `course` field comes with `null`, checked that `positions_messages` and `messages_segmented_` has rows with `course` value `null`.
Made the following commits:
* handle case where there is no valid speed and/or course
* fix null course (or speed) in SortByTime
* case where course is None when speed is very slow, then course is 0.
