### PR TITLE
Adds PipelineOptions to each TestPipeline to make tests work

### DIFF
--- a/pipeline/utils/ver.py
+++ b/pipeline/utils/ver.py
@@ -3,4 +3,4 @@ import re
 def get_pipe_ver():
     """Returns the version of the package."""
     with open('setup.py') as rf:
-        return re.search(r'version=\'([0-9.]*)\'', rf.read()).group(1)
+        return re.search(r"version='([0-9.]*)'", rf.read()).group(1)

--- a/tests/test_compute_adjacency.py
+++ b/tests/test_compute_adjacency.py
@@ -13,6 +13,7 @@ from apache_beam.testing.util import assert_that
 from .test_resample import Record
 from .test_resample import ResampledRecord
 from .series_data import simple_series_data
+from pipeline.options.create_options import CreateOptions
 from pipeline.transforms import compute_adjacency
 from pipeline.transforms import resample
 from pipeline.objects import record
@@ -52,7 +53,16 @@ class TestComputeAdjacency(unittest.TestCase):
 
         tuple_data = [tuple(x) for x in simple_series_data]
 
-        with _TestPipeline() as p:
+        args = [
+            f"--source_table={tuple_data}",
+            "--raw_table=test",
+            "--start_date=2011-01-01",
+            "--end_date=2011-01-01",
+            "--max_encounter_dist_km=0.5",
+            "--min_encounter_time_minutes=120"
+        ]
+        opts = CreateOptions(args)
+        with _TestPipeline(options=opts) as p:
             results = (
                 p
                 | beam.Create(tuple_data)


### PR DESCRIPTION
* Test were missing the PipelineOptions for run the TestPipeline and when running with `pytest` they failed. Made the adapts to run the `TestPipeline` with expected arguments.

Related with> https://globalfishingwatch.atlassian.net/browse/PIPELINE-1145