### PR TITLE
Pipe-v2.5: Adds support for python-3.8 and AB-2.49

### DIFF
--- a/Dockerfile-scheduler
+++ b/Dockerfile-scheduler
@@ -1,4 +1,4 @@
-FROM gcr.io/world-fishing-827/github.com/globalfishingwatch/gfw-pipeline:latest-python3.7
+FROM gcr.io/world-fishing-827/github.com/globalfishingwatch/gfw-pipeline:latest-python3.8
 
 # Setup scheduler-specific dependencies
 COPY ./requirements-scheduler.txt ./

--- a/Dockerfile-worker
+++ b/Dockerfile-worker
@@ -1,6 +1,9 @@
-FROM apache/beam_python3.7_sdk:2.40.0
+FROM apache/beam_python3.8_sdk:2.49.0
 
 # Setup local application dependencies
 COPY ./requirements-worker.txt ./
 RUN pip install -r requirements-worker.txt
+
+# Set the entrypoint to the Apache Beam SDK launcher.
+ENTRYPOINT ["/opt/apache/beam/boot"]
 

--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -2,12 +2,12 @@
 Apache Beam pipeline for computing vessel encounters.
 """
 
-__version__ = '3.3.2'
+__version__ = '3.4.0'
 __author__ = 'Global Fishing Watch'
 __email__ = 'info@globalfishingwatch.org'
 __source__ = 'https://github.com/GlobalFishingWatch/anchorages_pipeline'
 __license__ = """
-Copyright 2020 Global Fishing Watch Inc.
+Copyright 2023 Global Fishing Watch Inc.
 Authors:
 
 Tim Hochberg <tim@globalfishingwatch.org>

--- a/requirements-scheduler.txt
+++ b/requirements-scheduler.txt
@@ -1,3 +1,3 @@
-apache-beam[gcp]==2.40.0
+apache-beam[gcp]==2.49.0
 pytest==6.2.5
 more_itertools==8.12.0

--- a/requirements-worker.txt
+++ b/requirements-worker.txt
@@ -2,3 +2,4 @@ pipe-tools @ https://codeload.github.com/globalfishingwatch/pipe-tools/tar.gz/v4
 s2sphere==0.2.5
 ujson==1.35
 statistics==1.0.3.5
+more_itertools==8.12.0


### PR DESCRIPTION
This is for pipe-v2.5:
- Increments the support from `python-3.7` to `python-3.8`, it was required because the last version of AB only supports py3.8.
- Increments the Apache Beam version from [2.40](https://github.com/apache/beam/releases/tag/v2.40.0) to [2.49](https://github.com/apache/beam/releases/tag/v2.49.0)

Tests are running ok.

Also run the encounters steps, the results were set in the `scratch_matias_ttl_60_days`.

Related with> https://globalfishingwatch.atlassian.net/browse/PIPELINE-1319