### PR TITLE
Pipe-v3: Adds support for python-3.8 and AB-2.49

### DIFF
--- a/Dockerfile-scheduler
+++ b/Dockerfile-scheduler
@@ -1,4 +1,4 @@
-FROM gcr.io/world-fishing-827/github.com/globalfishingwatch/gfw-pipeline:latest-python3.7
+FROM gcr.io/world-fishing-827/github.com/globalfishingwatch/gfw-pipeline:latest-python3.8
 
 # Setup scheduler-specific dependencies
 COPY ./requirements-scheduler.txt ./

--- a/Dockerfile-worker
+++ b/Dockerfile-worker
@@ -1,4 +1,4 @@
-FROM apache/beam_python3.7_sdk:2.40.0
+FROM apache/beam_python3.8_sdk:2.49.0
 
 # Setup local application dependencies
 COPY ./requirements-worker.txt ./

--- a/requirements-scheduler.txt
+++ b/requirements-scheduler.txt
@@ -1,3 +1,3 @@
-apache-beam[gcp]==2.40.0
+apache-beam[gcp]==2.49.0
 more_itertools==8.12.0
-pytest==6.2.5
+pytest==7.2.2

--- a/requirements-worker.txt
+++ b/requirements-worker.txt
@@ -1,2 +1,3 @@
+more_itertools==8.12.0
 s2sphere==0.2.5
 statistics==1.0.3.5

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='encounters',
-    version='4.0.0',
+    version='4.1.0',
     packages=find_packages(exclude=['test*.*', 'tests'])
 )
 


### PR DESCRIPTION
This is for pipe-v3:
- Increments the support from `python-3.7` to `python-3.8`, it was required because the last version of AB only supports py3.8.
- Increments the Apache Beam version from [2.40](https://github.com/apache/beam/releases/tag/v2.40.0) to [2.49](https://github.com/apache/beam/releases/tag/v2.49.0)
- Adds the lib `more_itertools` in the `requirements-worker.txt` that is used [here](https://github.com/GlobalFishingWatch/encounters_pipeline/blob/release-v4/pipeline/transforms/resample.py#L4).

Tests are running ok.

Also run the encounters steps, the results were set in the `scratch_matias_ttl_60_days`.

Related with> https://globalfishingwatch.atlassian.net/browse/PIPELINE-1423