### PR TITLE
Disable partition filter enforcement over the encounters table

### DIFF
--- a/pipeline/transforms/writers.py
+++ b/pipeline/transforms/writers.py
@@ -60,7 +60,7 @@ Created by the encounters_pipeline: {self.ver}
                 "timePartitioning": {
                     "type": "MONTH",
                     "field": "start_time",
-                    "requirePartitionFilter": True
+                    "requirePartitionFilter": False
                 },
                 "clustering": {
                     "fields": ["start_time"]

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='encounters',
-    version='4.1.0',
+    version='4.1.1',
     packages=find_packages(exclude=['test*.*', 'tests'])
 )
 


### PR DESCRIPTION
- Disables the partition filter enforcement in the `encounters` table.
- Increments the project version.

Related with> https://globalfishingwatch.atlassian.net/browse/PIPELINE-1488