### PR TITLE
PIPELINE-4286: Floor coordinates when building gridcode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ namespaces = false
 
 [project]
 name = "pipe-encounters"
-version = "4.4.0"
+version = "4.5.0"
 description = "Tools for detecting vessel encounters."
 readme = "README.md"
 # license = "Apache-2.0"

--- a/src/pipe_encounters/merge_pipeline.py
+++ b/src/pipe_encounters/merge_pipeline.py
@@ -60,7 +60,8 @@ def create_queries(args):
                 CAST(UNIX_MICROS(end_time) AS FLOAT64) / 1000000 AS end_time,
                 format("lon:%+07.2f_lat:%+07.2f",
                   floor(cast(mean_longitude as numeric) / numeric '0.01') * numeric '0.01',
-                  floor(cast(mean_latitude as numeric) / numeric '0.01') * numeric '0.01') as gridcode
+                  floor(cast(mean_latitude as numeric) / numeric '0.01') * numeric '0.01')
+                as gridcode
         FROM `{raw_table}` events
         WHERE DATE(start_time) BETWEEN '{start}' AND '{end}'
           {condition}

--- a/src/pipe_encounters/merge_pipeline.py
+++ b/src/pipe_encounters/merge_pipeline.py
@@ -58,7 +58,9 @@ def create_queries(args):
         SELECT * except (start_time, end_time, encounter_id),
                 CAST(UNIX_MICROS(start_time) AS FLOAT64) / 1000000 AS start_time,
                 CAST(UNIX_MICROS(end_time) AS FLOAT64) / 1000000 AS end_time,
-                format("lon:%+07.2f_lat:%+07.2f", mean_longitude, mean_latitude) as gridcode,
+                format("lon:%+07.2f_lat:%+07.2f",
+                  floor(cast(mean_longitude as numeric) / numeric '0.01') * numeric '0.01',
+                  floor(cast(mean_latitude as numeric) / numeric '0.01') * numeric '0.01') as gridcode
         FROM `{raw_table}` events
         WHERE DATE(start_time) BETWEEN '{start}' AND '{end}'
           {condition}


### PR DESCRIPTION
See https://globalfishingwatch.atlassian.net/browse/PIPELINE-4286

The `gridcode` was formatted directly from the raw `mean_longitude` /` mean_latitude`, so rounding in the `%.2f` format could push an event into a neighbouring grid cell. This floors each coordinate to the 0.01 grid
resolution before formatting, so the gridcode maps deterministically to its cell.

This is basically the same change we implemented on [pipe-measures](https://github.com/GlobalFishingWatch/pipe-measures/pull/71) for this and we definitively need to extract this logic out so we can share it everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)